### PR TITLE
[#8] Bugfix: Download button not appearing after data loads

### DIFF
--- a/o_static/minimal.html
+++ b/o_static/minimal.html
@@ -22,7 +22,6 @@
     .spinner{display:inline-block;width:24px;height:24px;border:3px solid #f3f3f3;border-top:3px solid #007bff;border-radius:50%;animation:spin 1s linear infinite}
     @keyframes spin{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
     .loading-text{font-size:16px;color:#007bff;font-weight:500}
-    #download{display:none}
   </style>
   <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>


### PR DESCRIPTION
## Summary

Fix regression from #6 where download button was completely hidden after data loads.

### Root Cause

CSS rule `#download{display:none}` was permanently hiding the button element, even after the `hideLoading()` function showed the button-group container.

### Solution

Remove the permanent CSS display:none rule. The button-group container already controls visibility via `style="display:none"` on initial load.

### Changes

- Remove line 25: `#download{display:none}` from CSS

### Testing

- [x] Spinner visible on page load
- [x] Button hidden on page load
- [x] Data loads successfully
- [x] Spinner disappears
- [x] **Button appears after data loads** ✅

### References

- Fixes #8
- Regression from #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>