### PR TITLE
[#10] Enhancement: Add "Retour au site du groupe" button

### DIFF
--- a/10ENHANCEMENT_PLAN.md
+++ b/10ENHANCEMENT_PLAN.md
@@ -1,0 +1,117 @@
+# Enhancement #10: Add "Retour au site du groupe" Button
+
+## 📋 Summary
+
+Add a "Retour au site du groupe" button alongside the "Download PNG" button. The button appears after data loads and links to the group's website at https://sites.google.com/jgwill.com/serviteur/accueil
+
+## 🎯 Objectives
+
+1. **Add return button** with link to group website
+2. **Display alongside Download button** after data loads
+3. **Open in new tab** to preserve current page context
+4. **Maintain consistent styling** with existing buttons
+
+## 📊 Before/After Comparison
+
+### Before
+```
+[After data loads]
+⬇️ Download PNG
+```
+
+### After
+```
+[After data loads]
+🔙 Retour au site du groupe     ⬇️ Download PNG
+```
+
+## 🔧 Implementation Details
+
+### Changes Made
+
+#### 1. **HTML: New Button Link** (line 36)
+- Added `<a>` element with class `btn`
+- Link to: https://sites.google.com/jgwill.com/serviteur/accueil
+- Opens in new tab: `target="_blank"`
+- Emoji icon: 🔙 (back arrow)
+- Text: "Retour au site du groupe"
+
+```html
+<a href="https://sites.google.com/jgwill.com/serviteur/accueil" target="_blank" class="btn">🔙 Retour au site du groupe</a>
+<button id="download" class="btn">⬇️ Download PNG</button>
+```
+
+### Key Features
+
+1. **Same styling** as Download button (uses `.btn` class)
+2. **No new CSS needed** - reuses existing button styles
+3. **Flexbox layout** automatically positions buttons side-by-side
+4. **Visibility managed** by existing `showLoading()`/`hideLoading()` logic
+5. **New tab behavior** - preserves current page when clicking
+
+## 📁 Files Modified
+
+- `/home/gmusic/na/workspace/naas/o_static/minimal.html` (1 line added)
+
+## ✅ Testing Checklist
+
+- [x] Return button appears after data loads
+- [x] Download button still visible
+- [x] Both buttons side-by-side (flexbox layout)
+- [x] Return button link correct: https://sites.google.com/jgwill.com/serviteur/accueil
+- [x] Link opens in new tab
+- [x] Button styling consistent with Download button
+- [x] Loading state hides both buttons correctly
+- [x] Error state hides both buttons correctly
+
+## 🎸 Design Decisions
+
+1. **Link element** instead of button - semantic HTML for navigation
+2. **target="_blank"** - open group site without losing current page
+3. **Same `.btn` class** - consistent visual styling
+4. **Button order** - return button first (left), download button second (right)
+5. **No additional CSS** - leverages existing flexbox layout
+
+## 🚀 User Experience Flow
+
+```
+1. Page loads
+   ↓
+2. Spinner + "Traitement en cours..." appears
+   ↓
+3. Data fetches
+   ↓
+4. Table renders on-screen
+   ↓
+5. Spinner disappears
+   ↓
+6. Two buttons appear:
+   - 🔙 Retour au site du groupe (links to group website)
+   - ⬇️ Download PNG (downloads table as PNG)
+```
+
+## 🔍 Implementation Quality
+
+- **Minimal changes** - only 1 line added to HTML
+- **No JavaScript** - pure HTML link
+- **Accessibility** - semantic `<a>` tag with clear text
+- **Mobile-friendly** - flexbox layout adapts to screen size
+- **Future-proof** - easy to modify link or styling if needed
+
+## 📝 Technical Notes
+
+- Link uses full absolute URL to avoid routing issues
+- `target="_blank"` with `rel="noopener noreferrer"` would be safer, but not critical for this use case
+- `.btn` class styles both button elements and anchor elements consistently
+- Button-group container visibility already manages both buttons together
+
+## 🎯 Success Criteria Met
+
+- ✅ Return button visible after data loads
+- ✅ Positioned correctly with Download button
+- ✅ Links to correct group website
+- ✅ Opens in new tab
+- ✅ Consistent styling maintained
+- ✅ Minimal code changes
+- ✅ No new CSS required
+- ✅ Existing functionality preserved

--- a/o_static/minimal.html
+++ b/o_static/minimal.html
@@ -33,6 +33,7 @@
       <div class="loading-text">Traitement en cours...</div>
     </div>
     <div class="button-group" id="button-group" style="display:none">
+      <a href="https://sites.google.com/jgwill.com/serviteur/accueil" target="_blank" class="btn">🔙 Retour au site du groupe</a>
       <button id="download" class="btn">⬇️ Download PNG</button>
     </div>
     <div id="table-container"></div>


### PR DESCRIPTION
## Summary

Add a "Retour au site du groupe" button that appears alongside the "Download PNG" button after data loads. The button links to the group's website.

### Key Changes

- ✅ Add return button link to: https://sites.google.com/jgwill.com/serviteur/accueil
- ✅ Button appears after data loads (same visibility as Download button)
- ✅ Opens in new tab (`target="_blank"`)
- ✅ Consistent styling with existing buttons (uses `.btn` class)
- ✅ Minimal implementation (1 line HTML change)

### Files Changed

- `o_static/minimal.html` - Added return button link
- `10ENHANCEMENT_PLAN.md` - Implementation documentation

### Button Layout

After data loads, users see two buttons:
```
🔙 Retour au site du groupe     ⬇️ Download PNG
```

### Features

- **Semantic HTML** - Uses `<a>` element for navigation
- **New tab behavior** - Preserves current page when clicking
- **Consistent styling** - Reuses `.btn` class styling
- **Automatic layout** - Flexbox positions buttons side-by-side
- **Existing visibility** - Managed by showLoading()/hideLoading()

### Testing

- [x] Return button appears after data loads
- [x] Download button still visible
- [x] Both buttons positioned side-by-side
- [x] Link opens in new tab
- [x] Styling consistent with Download button
- [x] Loading state hides both buttons
- [x] Error state hides both buttons

### References

- Closes #10
- Plan document: `10ENHANCEMENT_PLAN.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>